### PR TITLE
Arrange diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ See [the examples](./examples/README.md) for more detailed usage
 * `noColors`: (default `false`) Removes colouring from console output, useful if storing the results in a file
 * `failureThreshold`: (default `0`) Sets the threshold that would trigger a test failure based on the `failureThresholdType` selected. This is different to the `customDiffConfig.threshold` above, that is the per pixel failure threshold, this is the failure threshold for the entire comparison.
 * `failureThresholdType`: (default `pixel`) (options `percent` or `pixel`) Sets the type of threshold that would trigger a failure.
+* `verticalDiffArrange`: (default `null`) Sets type of diff images arrange. `true` for vertically places images: original, diff and current. 'false' for horizontally aligned images. 'null' for saving diff image only.
 
 ```javascript
   it('should demonstrate this matcher`s usage with a custom pixelmatch config', () => {

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See [the examples](./examples/README.md) for more detailed usage
 * `noColors`: (default `false`) Removes colouring from console output, useful if storing the results in a file
 * `failureThreshold`: (default `0`) Sets the threshold that would trigger a test failure based on the `failureThresholdType` selected. This is different to the `customDiffConfig.threshold` above, that is the per pixel failure threshold, this is the failure threshold for the entire comparison.
 * `failureThresholdType`: (default `pixel`) (options `percent` or `pixel`) Sets the type of threshold that would trigger a failure.
-* `verticalDiffArrange`: (default `null`) Sets type of diff images arrange. `true` for vertically places images: original, diff and current. 'false' for horizontally aligned images. 'null' for saving diff image only.
+* `verticalDiffArrange`: (default `null`) Sets type of diff images arrange. `true` for vertically places images: original, diff and current. `false` for horizontally aligned images. `null` for saving diff image only.
 
 ```javascript
   it('should demonstrate this matcher`s usage with a custom pixelmatch config', () => {

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -9,6 +9,7 @@ Object {
   "snapshotIdentifier": "test-spec-js-test-1",
   "snapshotsDir": "path/to/__image_snapshots__",
   "updateSnapshot": false,
+  "verticalDiffArrange": null,
 }
 `;
 

--- a/__tests__/diff-snapshot.spec.js
+++ b/__tests__/diff-snapshot.spec.js
@@ -166,6 +166,72 @@ describe('diff-snapshot', () => {
       expect(mockSpawn.calls[0].opts.input).toEqual(expect.any(Buffer));
     });
 
+    it('should write a diff image if the test fails with vertical diff arrange', () => {
+      const diffImageToSnapshot = setupTest({ snapshotExists: true, pixelmatchResult: 5000 });
+      const result = diffImageToSnapshot({
+        receivedImageBuffer: mockFailImageBuffer,
+        snapshotIdentifier: mockSnapshotIdentifier,
+        snapshotsDir: mockSnapshotsDir,
+        updateSnapshot: false,
+        failureThreshold: 0,
+        failureThresholdType: 'pixel',
+        verticalDiffArrange: true,
+      });
+
+      expect(result).toMatchObject({
+        diffOutputPath: path.join(mockSnapshotsDir, '__diff_output__', 'id1-diff.png'),
+        diffRatio: 0.5,
+        diffPixelCount: 5000,
+        pass: false,
+      });
+      expect(mockPixelMatch).toHaveBeenCalledTimes(1);
+      expect(mockPixelMatch).toHaveBeenCalledWith(
+        expect.any(Buffer),
+        expect.any(Buffer),
+        expect.any(Buffer),
+        100,
+        100,
+        { threshold: 0.01 }
+      );
+
+      expect(mockSpawn.calls[0].args[0]).toBe(path.resolve('./src/write-result-diff-image.js'));
+      expect(mockSpawn.calls[0].command).toBe('node');
+      expect(mockSpawn.calls[0].opts.input).toEqual(expect.any(Buffer));
+    });
+
+    it('should write a diff image if the test fails with horizontal diff arrange', () => {
+      const diffImageToSnapshot = setupTest({ snapshotExists: true, pixelmatchResult: 5000 });
+      const result = diffImageToSnapshot({
+        receivedImageBuffer: mockFailImageBuffer,
+        snapshotIdentifier: mockSnapshotIdentifier,
+        snapshotsDir: mockSnapshotsDir,
+        updateSnapshot: false,
+        failureThreshold: 0,
+        failureThresholdType: 'pixel',
+        verticalDiffArrange: false,
+      });
+
+      expect(result).toMatchObject({
+        diffOutputPath: path.join(mockSnapshotsDir, '__diff_output__', 'id1-diff.png'),
+        diffRatio: 0.5,
+        diffPixelCount: 5000,
+        pass: false,
+      });
+      expect(mockPixelMatch).toHaveBeenCalledTimes(1);
+      expect(mockPixelMatch).toHaveBeenCalledWith(
+        expect.any(Buffer),
+        expect.any(Buffer),
+        expect.any(Buffer),
+        100,
+        100,
+        { threshold: 0.01 }
+      );
+
+      expect(mockSpawn.calls[0].args[0]).toBe(path.resolve('./src/write-result-diff-image.js'));
+      expect(mockSpawn.calls[0].command).toBe('node');
+      expect(mockSpawn.calls[0].opts.input).toEqual(expect.any(Buffer));
+    });
+
     it('should pass <= failureThreshold pixel', () => {
       const diffImageToSnapshot = setupTest({ snapshotExists: true, pixelmatchResult: 250 });
       const result = diffImageToSnapshot({

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -308,6 +308,7 @@ describe('toMatchImageSnapshot', () => {
       updateSnapshot: false,
       failureThreshold: 0,
       failureThresholdType: 'pixel',
+      verticalDiffArrange: null,
     });
     expect(Chalk).toHaveBeenCalledWith({
       enabled: false,

--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -19,6 +19,21 @@ const pixelmatch = require('pixelmatch');
 const mkdirp = require('mkdirp');
 const { PNG } = require('pngjs');
 
+function renderImages(sourceImages, imageWidth, imageHeight) {
+  const compositeResultImage = new PNG({
+    width: imageWidth * sourceImages.length,
+    height: imageHeight,
+  });
+  for (let i = 0; i < sourceImages.length; i++) {
+    PNG.bitblt(
+      sourceImage[i], compositeResultImage,
+      0, 0, imageWidth, imageHeight,
+      imageHeight * i, 0,
+    );
+  }
+  return compositeResultImage;
+}
+
 function diffImageToSnapshot(options) {
   const {
     receivedImageBuffer,
@@ -76,19 +91,9 @@ function diffImageToSnapshot(options) {
 
     if (!pass) {
       mkdirp.sync(outputDir);
-      const compositeResultImage = new PNG({
-        width: imageWidth * 3,
-        height: imageHeight,
-      });
-      // copy baseline, diff, and received images into composite result image
-      PNG.bitblt(
-        baselineImage, compositeResultImage, 0, 0, imageWidth, imageHeight, 0, 0
-      );
-      PNG.bitblt(
-        diffImage, compositeResultImage, 0, 0, imageWidth, imageHeight, imageWidth, 0
-      );
-      PNG.bitblt(
-        receivedImage, compositeResultImage, 0, 0, imageWidth, imageHeight, imageWidth * 2, 0
+      const compositeResultImage = renderImages(
+        [baselineImage, diffImage, receivedImage],
+        imageWidth, imageHeight,
       );
 
       const input = { imagePath: diffOutputPath, image: compositeResultImage };

--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -19,6 +19,21 @@ const pixelmatch = require('pixelmatch');
 const mkdirp = require('mkdirp');
 const { PNG } = require('pngjs');
 
+function renderImages(sourceImages, imageWidth, imageHeight) {
+  const compositeResultImage = new PNG({
+    width: imageWidth * sourceImages.length,
+    height: imageHeight,
+  });
+  for (let i = 0; i < sourceImages.length; i += 1) {
+    PNG.bitblt(
+      sourceImages[i], compositeResultImage,
+      0, 0, imageWidth, imageHeight,
+      imageHeight * i, 0
+    );
+  }
+  return compositeResultImage;
+}
+
 function diffImageToSnapshot(options) {
   const {
     receivedImageBuffer,
@@ -76,19 +91,9 @@ function diffImageToSnapshot(options) {
 
     if (!pass) {
       mkdirp.sync(outputDir);
-      const compositeResultImage = new PNG({
-        width: imageWidth * 3,
-        height: imageHeight,
-      });
-      // copy baseline, diff, and received images into composite result image
-      PNG.bitblt(
-        baselineImage, compositeResultImage, 0, 0, imageWidth, imageHeight, 0, 0
-      );
-      PNG.bitblt(
-        diffImage, compositeResultImage, 0, 0, imageWidth, imageHeight, imageWidth, 0
-      );
-      PNG.bitblt(
-        receivedImage, compositeResultImage, 0, 0, imageWidth, imageHeight, imageWidth * 2, 0
+      const compositeResultImage = renderImages(
+        [baselineImage, diffImage, receivedImage],
+        imageWidth, imageHeight
       );
 
       const input = { imagePath: diffOutputPath, image: compositeResultImage };

--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -29,8 +29,8 @@ function renderImages(sourceImages, imageWidth, imageHeight, isVertical) {
     PNG.bitblt(
       sourceImages[i], compositeResultImage,
       0, 0, imageWidth, imageHeight,
-      isVertical ? 0 : imageHeight * i,
-      isVertical ? imageWidth * i : 0
+      isVertical ? 0 : imageWidth * i,
+      isVertical ? imageHeight * i : 0
     );
   }
   return compositeResultImage;

--- a/src/diff-snapshot.js
+++ b/src/diff-snapshot.js
@@ -20,11 +20,12 @@ const mkdirp = require('mkdirp');
 const { PNG } = require('pngjs');
 
 function renderImages(sourceImages, imageWidth, imageHeight) {
+  const imagesCount = sourceImages.length;
   const compositeResultImage = new PNG({
-    width: imageWidth * sourceImages.length,
+    width: imageWidth * imagesCount,
     height: imageHeight,
   });
-  for (let i = 0; i < sourceImages.length; i += 1) {
+  for (let i = 0; i < imagesCount; i += 1) {
     PNG.bitblt(
       sourceImages[i], compositeResultImage,
       0, 0, imageWidth, imageHeight,

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ function configureToMatchImageSnapshot({
   noColors: commonNoColors = false,
   failureThreshold: commonFailureThreshold = 0,
   failureThresholdType: commonFailureThresholdType = 'pixel',
+  verticalDiffArrange: commonVerticalDiffArrange = null,
 } = {}) {
   return function toMatchImageSnapshot(received, {
     customSnapshotIdentifier = '',
@@ -37,6 +38,7 @@ function configureToMatchImageSnapshot({
     noColors = commonNoColors,
     failureThreshold = commonFailureThreshold,
     failureThresholdType = commonFailureThresholdType,
+    verticalDiffArrange = commonVerticalDiffArrange,
   } = {}) {
     const { testPath, currentTestName, isNot } = this;
     const chalk = new Chalk({ enabled: !noColors });
@@ -55,6 +57,7 @@ function configureToMatchImageSnapshot({
       customDiffConfig: Object.assign({}, commonCustomDiffConfig, customDiffConfig),
       failureThreshold,
       failureThresholdType,
+      verticalDiffArrange,
     });
 
     let pass = true;


### PR DESCRIPTION
Allow to arrange images (original, diff and current) in output image vertically, horizontally or leave there only the diff.
Vertical arrange can be usable for wide images.